### PR TITLE
fix two eye bug in password screen

### DIFF
--- a/src/app.pcss
+++ b/src/app.pcss
@@ -13,3 +13,15 @@ html, body {
   margin: 0;
   padding: 0;
 }
+
+.passphrase-input::-ms-reveal {
+  display: none;
+}
+
+.passphrase-input::-webkit-credentials-auto-fill-button {
+  display: none !important;
+}
+
+.passphrase-input::-webkit-password-toggle-button {
+  display: none !important;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,7 @@
 	<div class='flex flex-col {isSm ? 'mx-8' : 'mx-[30%]'} gap-y-2 mt-[160px] justify-center'>
 		<div class='flex relative'>
 			<Input 
-				class='rounded-none pr-20' 
+				class='rounded-none pr-20 passphrase-input' 
 				type={showPassword ? 'text' : 'password'} 
 				name='passphrase' 
 				autocomplete='off' 


### PR DESCRIPTION
Hello Max

/src/routes/+page.svelte

There was an extra whitespace on line 28 that I removed

In the input field for the password, I added these to the tailwindcss class:
1. [&::-ms-reveal]:hidden 
2. [&::-webkit-credentials-auto-fill-button]:hidden 
3. [&::-webkit-password-toggle-button]:hidden

1 hides the reveal button in Internet Explorer/Edge
2 hides the auto-fill button in WebKit browsers
3 hides the password toggle button in WebKit browsers